### PR TITLE
Update 8.Docker Compose.md

### DIFF
--- a/docs/8.Docker Compose.md
+++ b/docs/8.Docker Compose.md
@@ -132,14 +132,14 @@ CMD ["python", "app.py"]
 ```yaml
 version: '3'
 services:
-  web:    
-  build: .    
-  ports:    
-  - "5000:5000"
-  volumes:
-       - .:/code
-  redis:    
-  image: "redis:alpine"
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/code
+  redis:
+    image: "redis:alpine"
 ```
 
 运行 compose 项目:


### PR DESCRIPTION
更新这里的格式 不然直接复制会报错ERROR: In file './docker-compose.yml', service 'build' must be a mapping not a string.